### PR TITLE
Optionally emulate Jaguar sound propagation mode

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -611,6 +611,7 @@ static void M_ID_LinearSky (int choice);
 static void M_ID_FlipCorpses (int choice);
 static void M_ID_Crosshair (int choice);
 static void M_ID_CrosshairColor (int choice);
+static void M_ID_JaguarSndProp (int choice);
 
 static void M_Choose_ID_Gameplay_2 (int choice);
 static void M_Draw_ID_Gameplay_2 (void);
@@ -2751,7 +2752,7 @@ static menuitem_t ID_Menu_Gameplay_1[]=
     { M_LFRT, "SHAPE",                       M_ID_Crosshair,         's' },
     { M_LFRT, "INDICATION",                  M_ID_CrosshairColor,    'i' },
     { M_SKIP, "", 0, '\0' },
-    { M_SKIP, "", 0, '\0' },
+    { M_LFRT, "SOUND PROPAGATION MODE",      M_ID_JaguarSndProp,     's' },
     //{ M_SKIP, "", 0, '\0' },
     { M_SWTC, "", /*NEXT PAGE >*/            M_Choose_ID_Gameplay_2, 'n' },
 };
@@ -2846,6 +2847,13 @@ static void M_Draw_ID_Gameplay_1 (void)
     M_WriteText (M_ItemRightAlign(str), 117, str,
                  M_Item_Glow(11, xhair_color ? GLOW_GREEN : GLOW_DARKRED));
 
+    M_WriteTextCentered(126, "AUDIBLE", cr[CR_YELLOW]);
+
+    // Sound propagation mode
+    sprintf(str, aud_jaguar_prop ? "JAGUAR" : "PC");
+    M_WriteText (M_ItemRightAlign(str), 135, str,
+                 M_Item_Glow(13, aud_jaguar_prop ? GLOW_DARKRED : GLOW_GREEN));
+
     // Footer
     M_WriteText (ID_MENU_LEFTOFFSET_BIG, 144, "NEXT PAGE >",
                  M_Item_Glow(14, GLOW_LIGHTGRAY));
@@ -2915,6 +2923,11 @@ static void M_ID_Crosshair (int choice)
 static void M_ID_CrosshairColor (int choice)
 {
     xhair_color = M_INT_Slider(xhair_color, 0, 3, choice, false);
+}
+
+static void M_ID_JaguarSndProp (int choice)
+{
+    aud_jaguar_prop ^= 1;
 }
 
 // -----------------------------------------------------------------------------
@@ -3197,6 +3210,9 @@ static void M_ID_ApplyResetHook (void)
     // Crosshair
     xhair_draw = 0;
     xhair_color = 0;
+
+    // Audible
+    aud_jaguar_prop = 1;
 
     // Status bar
     st_colored_stbar = 0;

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -31,6 +31,7 @@
 #include "doomstat.h"
 
 #include "id_func.h"
+#include "id_vars.h"
 
 
 typedef enum
@@ -645,7 +646,8 @@ void A_Look (mobj_t* actor)
     {
 	actor->target = targ;
 
-	if ( actor->flags & MF_AMBUSH )
+	// [JN] CRY: optionally emulate Jaguar sound propagation mode.
+	if ( aud_jaguar_prop || actor->flags & MF_AMBUSH )
 	{
 	    if (P_CheckSight (actor, actor->target))
 		goto seeyou;

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -113,6 +113,9 @@ int vis_flip_corpses = 0;
 int xhair_draw = 0;
 int xhair_color = 0;
 
+// Audible
+int aud_jaguar_prop = 1;
+
 // Status bar
 int st_colored_stbar = 0;
 int st_negative_health = 0;

--- a/src/id_vars.h
+++ b/src/id_vars.h
@@ -89,6 +89,8 @@ extern int vis_flip_corpses;
 extern int xhair_draw;
 extern int xhair_color;
 
+extern int aud_jaguar_prop;
+
 extern int st_colored_stbar;
 extern int st_negative_health;
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -441,6 +441,9 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(xhair_draw),
     CONFIG_VARIABLE_INT(xhair_color),
 
+    // Audible
+    CONFIG_VARIABLE_INT(aud_jaguar_prop),
+
     // Status Bar
     CONFIG_VARIABLE_INT(st_colored_stbar),
     CONFIG_VARIABLE_INT(st_negative_health),


### PR DESCRIPTION
* Not quite exactly how it is done in the Jaguar code, but behaves exactly the same way w/o too much code rewriting.
* Optional, because in this mode all monsters are very "sleepy", making whole gameplay a bit less dynamical. There will be no hordes chasing the player.