### PR TITLE
Optionally emulate Jaguar sky texture definitions

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -771,6 +771,34 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     	CRL_ImpulseCamera(cmd->forwardmove, cmd->sidemove, cmd->angleturn); 
 } 
  
+// -----------------------------------------------------------------------------
+// G_InitSkyTextures
+// [JN] CRY: define sky textures with optional emulation. Jaguar skies are:
+// AREA 17 (Hell Keep) is using Deimos sky.
+// AREA 24 (Military base) is using hellish sky.
+// -----------------------------------------------------------------------------
+
+void G_InitSkyTextures (void)
+{
+    if (gamemap < 9 || (!emu_jaguar_skies && gamemap == 24))
+    {
+        skytexture = R_TextureNumForName("SKY1_1");
+        skytexture2 = R_TextureNumForName("SKY1_2");
+        skyscrollspeed = 40; // slow for Phobos levels
+    }
+    else if (gamemap < (emu_jaguar_skies ? 18 : 17))
+    {
+        skytexture = R_TextureNumForName("SKY2_1");
+        skytexture2 = R_TextureNumForName("SKY2_2");
+        skyscrollspeed = 60; // Middle for Deimos levels
+    }
+    else
+    {
+        skytexture = R_TextureNumForName("SKY3_1");
+        skytexture2 = R_TextureNumForName("SKY3_2");
+        skyscrollspeed = 75; // Fast for Hellish levels
+    }
+}
 
 //
 // G_DoLoadLevel 
@@ -795,25 +823,8 @@ void G_DoLoadLevel (void)
 
     skyflatnum = R_FlatNumForName(SKYFLATNAME);
 
-    // [JN] Set Jaguar skies.
-    if (gamemap < 9 || gamemap == 24)
-    {
-        skytexture = R_TextureNumForName("SKY1_1");
-        skytexture2 = R_TextureNumForName("SKY1_2");
-        skyscrollspeed = 40; // slow for Phobos levels
-    }
-    else if (gamemap < 17)
-    {
-        skytexture = R_TextureNumForName("SKY2_1");
-        skytexture2 = R_TextureNumForName("SKY2_2");
-        skyscrollspeed = 60; // Middle for Deimos levels
-    }
-    else
-    {
-        skytexture = R_TextureNumForName("SKY3_1");
-        skytexture2 = R_TextureNumForName("SKY3_2");
-        skyscrollspeed = 75; // Fast for Hellish levels
-    }
+    // [JN] Set Jaguar sky textures.
+    G_InitSkyTextures();
     
     levelstarttic = gametic;        // for time calculation
     

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -48,6 +48,7 @@ extern void G_DoWorldDone (void);
 extern void G_DrawMouseSpeedBox (void);
 extern void G_ExitLevel (void);
 extern void G_InitNew (skill_t skill, int episode, int map);
+extern void G_InitSkyTextures (void); 
 extern void G_LoadGame (char *name);
 extern void G_PlayerReborn (int player);
 extern void G_SaveGame (int slot, char *description);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -630,6 +630,7 @@ static void M_ID_FlipLevels (int choice);
 static void M_ID_OnDeathAction (int choice);
 static void M_ID_JaguarAlert (int choice);
 static void M_ID_JaguarExplosion (int choice);
+static void M_ID_JaguarSkies (int choice);
 
 static void M_ScrollGameplay (int choice);
 static void M_DrawGameplayFooter (char *pagenum);
@@ -3094,7 +3095,7 @@ static menuitem_t ID_Menu_Gameplay_3[]=
     { M_SKIP, "", 0, '\0' },
     { M_LFRT, "ALERTED MONSTERS BEHAVIOUR",    M_ID_JaguarAlert,       'a' },
     { M_LFRT, "EXPLOSION RADIUS IMPACT",       M_ID_JaguarExplosion,   'e' },
-    { M_SKIP, "", 0, '\0' },
+    { M_LFRT, "SKY TEXTURES",                  M_ID_JaguarSkies,       's' },
     { M_SKIP, "", 0, '\0' },
     { M_SKIP, "", 0, '\0' },
     { M_SKIP, "", 0, '\0' },
@@ -3160,6 +3161,11 @@ static void M_Draw_ID_Gameplay_3 (void)
     M_WriteText (M_ItemRightAlign(str), 81, str,
                  M_Item_Glow(7, emu_jaguar_explosion ? GLOW_DARKRED : GLOW_GREEN));
 
+    // Sky textures
+    sprintf(str, emu_jaguar_skies ? "JAGUAR" : "PC");
+    M_WriteText (M_ItemRightAlign(str), 90, str,
+                 M_Item_Glow(8, emu_jaguar_skies ? GLOW_DARKRED : GLOW_GREEN));
+
     // Print explanations of emulation accuracy features
     if (itemOn == 6 && emu_jaguar_alert)
     {
@@ -3170,6 +3176,11 @@ static void M_Draw_ID_Gameplay_3 (void)
     {
         M_WriteTextCentered(117, "SOLID WALLS DON'T BLOCK", cr[CR_GRAY]);
         M_WriteTextCentered(126, "EXPLOSION RADIUS DAMAGE", cr[CR_GRAY]);
+    }
+    if (itemOn == 8 && emu_jaguar_skies)
+    {
+        M_WriteTextCentered(117, "AREA 17 USES DEIMOS SKY", cr[CR_GRAY]);
+        M_WriteTextCentered(126, "AREA 24 USES HELLISH SKY", cr[CR_GRAY]);
     }
 
     // Footer
@@ -3217,6 +3228,14 @@ static void M_ID_JaguarAlert (int choice)
 static void M_ID_JaguarExplosion (int choice)
 {
     emu_jaguar_explosion ^= 1;
+}
+
+static void M_ID_JaguarSkies (int choice)
+{
+    emu_jaguar_skies ^= 1;
+
+    // [JN] (Re-)set Jaguar sky textures.
+    G_InitSkyTextures();
 }
 
 static void M_ScrollGameplay (int choice)
@@ -3360,6 +3379,7 @@ static void M_ID_ApplyResetHook (void)
     // Emulation accuracy
     emu_jaguar_alert = 1;
     emu_jaguar_explosion = 1;
+    emu_jaguar_skies = 1;
 
     // Compatibility-breaking
     compat_vertical_aiming = 0;
@@ -3379,6 +3399,7 @@ static void M_ID_ApplyResetHook (void)
     {
         AM_Start();
     }
+    G_InitSkyTextures();
 
     // Restart audio systems
     S_StopMusic();

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -50,6 +50,7 @@
 #include "v_trans.h"
 #include "am_map.h"
 #include "st_bar.h"
+#include "r_collit.h"
 
 #include "id_vars.h"
 #include "id_func.h"
@@ -3234,8 +3235,12 @@ static void M_ID_JaguarSkies (int choice)
 {
     emu_jaguar_skies ^= 1;
 
-    // [JN] (Re-)set Jaguar sky textures.
+    // Reset Jaguar sky textures.
     G_InitSkyTextures();
+    // Redefine color table for colored lighting.
+    P_SetSectorColorTable(24);
+    // Refill colored lighting values.
+    P_ReloadSectorColorTable(24);
 }
 
 static void M_ScrollGameplay (int choice)

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -598,6 +598,7 @@ extern void A_BFGSpray (mobj_t *mo);
 extern void A_Explode (mobj_t *thingy);
 extern void A_PlayerScream (mobj_t* mo);
 
+extern boolean canmodify;
 extern double  P_SlopeFOVCorrecton (void);
 extern fixed_t bulletslope;
 

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -67,7 +67,7 @@ int		numsides;
 side_t*		sides;
 
 static int      totallines;
-static boolean  canmodify;
+boolean  canmodify;
 
 // BLOCKMAP
 // Created from axis aligned bounding box

--- a/src/doom/r_collit.c
+++ b/src/doom/r_collit.c
@@ -19,6 +19,7 @@
 
 #include "z_zone.h"
 #include "doomstat.h"
+#include "p_local.h"
 #include "r_collit.h"
 
 #include "id_vars.h"
@@ -2681,6 +2682,101 @@ static const sectorcolor_t sectorcolor_map23[] =
 // Area 24: Military Base
 //
 
+// Hellish sky version with red lighting under sky
+static const sectorcolor_t sectorcolor_map24_emu[] =
+{
+    {   24,      0,    0xFFAFAF },
+    {   24,      1,    0xFFAFAF },
+    {   24,      2,    0xFFAFAF },
+    {   24,      3,    0xFFAFAF },
+    {   24,      5,    0xBBE357 },
+    {   24,     17,    0xFF7F7F },
+    {   24,     18,    0xFF7F7F },
+    {   24,     19,    0xFF7F7F },
+    {   24,     20,    0xFF7F7F },
+    {   24,     21,    0xFF7F7F },
+    {   24,     22,    0xFF7F7F },
+    {   24,     23,    0xBBE357 },
+    {   24,     24,    0x3089FF },
+    {   24,     25,    0x3089FF },
+    {   24,     26,    0xBBE357 },
+    {   24,     27,    0xBBE357 },
+    {   24,     28,    0xBBE357 },
+    {   24,     29,    0x55B828 },
+    {   24,     30,    0xBBE357 },
+    {   24,     31,    0xBBE357 },
+    {   24,     32,    0xBBE357 },
+    {   24,     33,    0xBBE357 },
+    {   24,     34,    0xBBE357 },
+    {   24,     35,    0xFF7F7F },
+    {   24,     36,    0xBBE357 },
+    {   24,     37,    0x55B828 },
+    {   24,     38,    0x55B828 },
+    {   24,     39,    0x55B828 },
+    {   24,     46,    0x55B828 },
+    {   24,     47,    0xFF7F7F },
+    {   24,     50,    0x55B828 },
+    {   24,     51,    0x55B828 },
+    {   24,     52,    0xBBE357 },
+    {   24,     53,    0xFF7F7F },
+    {   24,     58,    0xBBE357 },
+    {   24,     59,    0xBBE357 },
+    {   24,     60,    0xBBE357 },
+    {   24,     61,    0xBBE357 },
+    {   24,     62,    0xBBE357 },
+    {   24,     63,    0xFF7F7F },
+    {   24,     64,    0xBBE357 },
+    {   24,     65,    0xBBE357 },
+    {   24,     66,    0x55B828 },
+    {   24,     68,    0xFF7F7F },
+    {   24,     69,    0xFF7F7F },
+    {   24,     70,    0xFF7F7F },
+    {   24,     71,    0xFF7F7F },
+    {   24,     72,    0xFF7F7F },
+    {   24,     73,    0xFF7F7F },
+    {   24,     74,    0xFF7F7F },
+    {   24,     80,    0xEEC06B },
+    {   24,     81,    0xFF7F7F },
+    {   24,     82,    0xFF7F7F },
+    {   24,     83,    0xFFAFAF },
+    {   24,     84,    0xFF7F7F },
+    {   24,     85,    0xFF7F7F },
+    {   24,     86,    0xFF7F7F },
+    {   24,     87,    0xFF7F7F },
+    {   24,     88,    0xFF7F7F },
+    {   24,     89,    0xFF7F7F },
+    {   24,     90,    0xFF7F7F },
+    {   24,     91,    0xFF7F7F },
+    {   24,     92,    0xFF7F7F },
+    {   24,     94,    0xECB866 },
+    {   24,     98,    0xFF7F7F },
+    {   24,     99,    0xECB866 },
+    {   24,    100,    0xECB866 },
+    {   24,    101,    0xFF7F7F },
+    {   24,    102,    0xFF7F7F },
+    {   24,    103,    0x55B828 },
+    {   24,    104,    0xFF7F7F },
+    {   24,    105,    0xFF7F7F },
+    {   24,    107,    0xFFF588 },
+    {   24,    113,    0xFFAFAF },
+    {   24,    115,    0xFFF588 },
+    {   24,    119,    0xFFF588 },
+    {   24,    120,    0xFFF588 },
+    {   24,    123,    0xFFAFAF },
+    {   24,    125,    0xFF7F7F },
+    {   24,    127,    0xFF7F7F },
+    {   24,    130,    0xD97C45 },
+    {   24,    133,    0xFF7F7F },
+    {   24,    136,    0xFF7F7F },
+    {   24,    145,    0x3089FF },
+    {   24,    146,    0xFF7F7F },
+    {   24,    147,    0xFFF588 },
+    {   24,    148,    0xFF7F7F },
+    {   24,    149,    0xFFF588 },
+    SECTORCOLOR_END
+};
+
+// Phobos sky version
 static const sectorcolor_t sectorcolor_map24[] =
 {
     {   24,      5,    0xBBE357 },
@@ -2763,8 +2859,46 @@ void P_SetSectorColorTable (int area)
         case 21:  sectorcolor = sectorcolor_map21;  break;
         case 22:  sectorcolor = sectorcolor_map22;  break;
         case 23:  sectorcolor = sectorcolor_map23;  break;
-        case 24:  sectorcolor = sectorcolor_map24;  break;
+        case 24:  sectorcolor = emu_jaguar_skies ? 
+                                sectorcolor_map24_emu :     // Hellish sky
+                                sectorcolor_map24;  break;  // Phobos sky
         default:  sectorcolor = sectorcolor_dummy;  break;
+    }
+}
+
+void P_ReloadSectorColorTable (int area)
+{
+    sector_t *ss = sectors;
+
+    // [JN] If current area is not a given one,
+    // do not bother to reinject color tables.
+    // In fact, only AREA 24 needs this function.
+    if (gamemap != area)
+    {
+        return;
+    }
+
+    // [JN] Inject color tables into the sectors of IWAD levels.
+    if (canmodify)
+    {
+        for (int i = 0 ; i < numsectors ; i++, ss++)
+        {
+            for (int j = 0; sectorcolor[j].map != -1; j++)
+            {
+                // [JN] Clear current lighting values.
+                ss->color = 0;
+                
+                // [JN] Re-inject lighting values.
+                if (i == sectorcolor[j].sector && gamemap == sectorcolor[j].map)
+                {
+                    if (sectorcolor[j].color)
+                    {
+                        ss->color = sectorcolor[j].color;
+                    }
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/src/doom/r_collit.h
+++ b/src/doom/r_collit.h
@@ -73,5 +73,6 @@ typedef struct
 
 extern const sectorcolor_t *sectorcolor;
 extern void  P_SetSectorColorTable (int area);
+extern void  P_ReloadSectorColorTable (int area);
 
 

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -137,6 +137,7 @@ int gp_death_use_action = 0;
 // Emulation accuracy
 int emu_jaguar_alert = 1;
 int emu_jaguar_explosion = 1;
+int emu_jaguar_skies = 1;
 
 // Compatibility-breaking
 int compat_vertical_aiming = 0;
@@ -255,6 +256,7 @@ void ID_BindVariables (void)
     // Monsters
     M_BindIntVariable("emu_jaguar_alert",               &emu_jaguar_alert);
     M_BindIntVariable("emu_jaguar_explosion",           &emu_jaguar_explosion);
+    M_BindIntVariable("emu_jaguar_skies",               &emu_jaguar_skies);
     
     M_BindIntVariable("compat_vertical_aiming",         &compat_vertical_aiming);
 }

--- a/src/id_vars.h
+++ b/src/id_vars.h
@@ -108,6 +108,7 @@ extern int gp_death_use_action;
 
 extern int emu_jaguar_alert;
 extern int emu_jaguar_explosion;
+extern int emu_jaguar_skies;
 
 // Compatibility-breaking
 extern int compat_vertical_aiming;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -465,6 +465,7 @@ static default_t	doom_defaults_list[] =
     // Emulation accuracy
     CONFIG_VARIABLE_INT(emu_jaguar_alert),
     CONFIG_VARIABLE_INT(emu_jaguar_explosion),
+    CONFIG_VARIABLE_INT(emu_jaguar_skies),
 
     // Compatibility-breaking
     CONFIG_VARIABLE_INT(compat_vertical_aiming),


### PR DESCRIPTION
As suggested by **SiFi270** at [DoomWorld](https://www.doomworld.com/forum/topic/127710-international-doom-75-updated-june-29-2024-jaguar-is-back/?do=findComment&comment=2848614).

* Add "Sky Textures" to "Emulation Accuracy" section.
* By default, emulate Jaguar definitions, where:
  * Area 17 (Hell Keep) is using Deimos sky.
  * Area 24 (Military base) is using hellish sky.
* Dynamically change colored lighting for Area 24 upon toggling this feature.